### PR TITLE
feat: activate extension on localhost

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,8 @@
   "permissions": ["cookies"],
   "host_permissions": [
     "https://*.vercel.app/*",
-    "https://staging.signavio.com/*"
+    "https://staging.signavio.com/*",
+    "https://localhost:8080/*"
   ],
   "action": {
     "default_popup": "popup.html"


### PR DESCRIPTION
- this allows using the extension on localhost, in case the manual login does not work